### PR TITLE
Add filter redirect URL capability

### DIFF
--- a/src/main/java/com/bitium/saml/servlet/SsoLoginServlet.java
+++ b/src/main/java/com/bitium/saml/servlet/SsoLoginServlet.java
@@ -138,7 +138,21 @@ public abstract class SsoLoginServlet extends HttpServlet {
                 redirectUrl = getDashboardUrl();
             }
         }
+        redirectUrl = filterRedirectUrl(redirectUrl);
         response.sendRedirect(redirectUrl);
+    }
+    
+    /**
+     * Filters a redirect URL before redirection happens.
+     * <p>
+     * This method should be overridden to have final control of the redirect URL.
+     * 
+     * @param redirectUrl The redirect URL to be filtered.
+     * @return The filtered redirect URL.
+     */
+    protected String filterRedirectUrl(String redirectUrl) {
+        // Default implementation just passes through the URL
+        return redirectUrl;
     }
 
     protected void redirectToLoginWithSAMLError(HttpServletResponse response, Exception exception, String string) throws ServletException {


### PR DESCRIPTION
This enables downstream applications, specifically Jira in this case, to be able to filter the redirect URL before redirection happens.

This allows Jira to work around a dashboard redirection bug.

https://github.com/bitium/jira-saml-plugin/issues/46